### PR TITLE
Allow for newer Python versions, Python dependencies.

### DIFF
--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.10', '3.11', '3.12']
     steps:
 
     - uses: actions/checkout@v4

--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -26,11 +26,19 @@ jobs:
         python -m pip install --upgrade pip setuptools
         pip install tox-gh-actions
 
-    - name: Run tox
+    - name: Lint
+      if: ${{matrix.python-version == '3.10'}}
       run: |
         tox -e lint
-        tox -e coverage
+
+    - name: Run tests for all Pythons
+      run: |
         tox -e unit
+
+    - name: Run coverage
+      if: ${{matrix.python-version == '3.10'}}
+      run: |
+        tox -e coverage
 
     - name: Upload to codecov
       if: ${{matrix.python-version == '3.10'}}

--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.10', '3.11', '3.12']
     steps:
 
     - uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         "dask-mpi==2022.4.0",
     ],
     packages=find_packages(),
-    python_requires="==3.10.*",
+    python_requires=">=3.10",
     extras_require={"docs": ["sphinx", "sphinx-bluebrain-theme"]},
     entry_points={
         "console_scripts": [
@@ -59,6 +59,8 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Bio-Informatics",
     ],

--- a/setup.py
+++ b/setup.py
@@ -32,16 +32,16 @@ setup(
     license="Apache-2",
     install_requires=[
         "bluepysnap==3.0.1",
-        "numpy==1.24.3",
-        "pandas==2.0.2",
-        "progressbar==2.5",
-        "pyarrow==14.0.1",
-        "scipy==1.10.1",
-        "scikit-learn==1.5.0",
-        "voxcell==3.1.5",
-        "tables==3.8.0",  # Optional dependency of pandas.DataFrame.to_hdf()
-        "distributed==2023.6.0",  # Dask
-        "dask-mpi==2022.4.0",
+        "numpy>=1.24.3",
+        "pandas>=2.0.2",
+        "progressbar>=2.5",
+        "pyarrow>=14.0.1",
+        "scipy>=1.10.1",
+        "scikit-learn>=1.5.0",
+        "voxcell>=3.1.5",
+        "tables>=3.8.0",  # Optional dependency of pandas.DataFrame.to_hdf()
+        "distributed>=2023.6.0",  # Dask
+        "dask-mpi>=2022.4.0",
     ],
     packages=find_packages(),
     python_requires=">=3.10",


### PR DESCRIPTION
Is there a particular reason we have a pin for Python 3.10 only?

Same actually goes for the rest of the dependencies - this makes packaging connectome-manipulator near impossible in a reasonable way.